### PR TITLE
Fixed Python 3.9+ depreciation error:  Changed "tostring()" to "tobytes()"

### DIFF
--- a/cp2130/chip/chip.py
+++ b/cp2130/chip/chip.py
@@ -92,7 +92,7 @@ class CP2130Chip(object, six.with_metaclass(ChipBase)):
 
     def do_in_command(self, cmd):
         data = self.usb_device.control_transfer(cmd.bm_request_type, cmd.b_request, cmd.w_value, cmd.w_index, cmd.w_length)
-        return cmd.to_register(data.tostring())
+        return cmd.to_register(data.tobytes())
 
     def do_out_command(self, cmd, register):
         data = cmd.to_data(register)


### PR DESCRIPTION
Fixed Python 3.9+ depreciation error: 

AttributeError: 'array.array' object has no attribute 'tostring'

array.array: tostring() and fromstring() methods have been removed. They were aliases to tobytes() and frombytes()